### PR TITLE
Feature: Create provider and client 

### DIFF
--- a/app/src/main/java/com/example/myrecipebook/rest/api/RecipesRequest.kt
+++ b/app/src/main/java/com/example/myrecipebook/rest/api/RecipesRequest.kt
@@ -1,0 +1,32 @@
+package com.example.myrecipebook.rest.api
+
+import com.example.myrecipebook.rest.message.RecipeMessage
+import com.example.myrecipebook.rest.message.RecipesPageMessage
+import io.reactivex.rxjava3.core.Single
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * Retrofit API for DummyJSON Recipes endpoints.
+ * Base URL: https://dummyjson.com/
+ */
+interface RecipesRequest {
+    /**
+     * GET /recipes
+     * Supports pagination using [limit] and [skip].
+     */
+    @GET("recipes")
+    fun getRecipes(
+        @Query("limit") limit: Int? = null,
+        @Query("skip") skip: Int? = null
+    ): Single<RecipesPageMessage>
+
+    /**
+     * GET /recipes/{id}
+     */
+    @GET("recipes/{id}")
+    fun getRecipeById(
+        @Path("id") id: Int
+    ): Single<RecipeMessage>
+}

--- a/app/src/main/java/com/example/myrecipebook/rest/datasource/RecipesDataSource.kt
+++ b/app/src/main/java/com/example/myrecipebook/rest/datasource/RecipesDataSource.kt
@@ -1,0 +1,14 @@
+package com.example.myrecipebook.rest.datasource
+
+import com.example.myrecipebook.common.domain.model.Recipe
+import com.example.myrecipebook.common.domain.model.RecipesPage
+import io.reactivex.rxjava3.core.Single
+
+/**
+ * Abstração da fonte de dados remota para Recipes.
+ * Expõe apenas modelos de domínio para camadas superiores.
+ */
+interface RecipesDataSource {
+    fun getRecipes(limit: Int? = null, skip: Int? = null): Single<RecipesPage>
+    fun getRecipeById(id: Int): Single<Recipe>
+}

--- a/app/src/main/java/com/example/myrecipebook/rest/datasource/RecipesDataSourceImp.kt
+++ b/app/src/main/java/com/example/myrecipebook/rest/datasource/RecipesDataSourceImp.kt
@@ -1,0 +1,24 @@
+package com.example.myrecipebook.rest.datasource
+
+import com.example.myrecipebook.common.domain.model.Recipe
+import com.example.myrecipebook.common.domain.model.RecipesPage
+import com.example.myrecipebook.rest.api.RecipesRequest
+import com.example.myrecipebook.rest.mapper.RecipeMapper
+import io.reactivex.rxjava3.core.Single
+
+/**
+ * Implementação concreta da fonte de dados remota usando DummyJSON.
+ * Mapeia DTOs para modelos de domínio e expõe apenas domínio.
+ */
+class RecipesDataSourceImp(
+    private val api: RecipesRequest
+) : RecipesDataSource {
+
+    override fun getRecipes(limit: Int?, skip: Int?): Single<RecipesPage> =
+        api.getRecipes(limit = limit, skip = skip)
+            .map { message -> RecipeMapper.toDomain(message) }
+
+    override fun getRecipeById(id: Int): Single<Recipe> =
+        api.getRecipeById(id)
+            .map { message -> RecipeMapper.toDomain(message) }
+}

--- a/app/src/main/java/com/example/myrecipebook/rest/mapper/RecipeMapper.kt
+++ b/app/src/main/java/com/example/myrecipebook/rest/mapper/RecipeMapper.kt
@@ -1,0 +1,46 @@
+package com.example.myrecipebook.rest.mapper
+
+import com.example.myrecipebook.common.domain.model.Difficulty
+import com.example.myrecipebook.common.domain.model.Recipe
+import com.example.myrecipebook.common.domain.model.RecipesPage
+import com.example.myrecipebook.rest.message.RecipeMessage
+import com.example.myrecipebook.rest.message.RecipesPageMessage
+
+/**
+ * Maps REST DTOs to domain models.
+ */
+object RecipeMapper {
+
+    fun toDomain(message: RecipeMessage): Recipe = Recipe(
+        id = message.id,
+        name = message.name,
+        ingredients = message.ingredients,
+        instructions = message.instructions,
+        prepTimeMinutes = message.prepTimeMinutes,
+        cookTimeMinutes = message.cookTimeMinutes,
+        servings = message.servings,
+        difficulty = message.difficulty.toDifficulty(),
+        cuisine = message.cuisine,
+        caloriesPerServing = message.caloriesPerServing,
+        tags = message.tags,
+        userId = message.userId,
+        image = message.image,
+        rating = message.rating,
+        reviewCount = message.reviewCount,
+        mealType = message.mealType
+    )
+
+    fun toDomain(page: RecipesPageMessage): RecipesPage = RecipesPage(
+        recipes = page.recipes.map { toDomain(it) },
+        total = page.total,
+        skip = page.skip,
+        limit = page.limit
+    )
+}
+
+private fun String.toDifficulty(): Difficulty = when (this.lowercase()) {
+    "easy" -> Difficulty.Easy
+    "medium" -> Difficulty.Medium
+    "hard" -> Difficulty.Hard
+    else -> Difficulty.Unknown
+}

--- a/app/src/main/java/com/example/myrecipebook/rest/network/NetworkProvider.kt
+++ b/app/src/main/java/com/example/myrecipebook/rest/network/NetworkProvider.kt
@@ -1,0 +1,62 @@
+package com.example.myrecipebook.rest.network
+
+import com.example.myrecipebook.BuildConfig
+import com.example.myrecipebook.rest.api.RecipesRequest
+import com.example.myrecipebook.rest.datasource.RecipesDataSourceImp
+import com.example.myrecipebook.rest.datasource.RecipesDataSource
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import com.squareup.moshi.Moshi
+import io.reactivex.rxjava3.schedulers.Schedulers
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory
+import retrofit2.converter.moshi.MoshiConverterFactory
+import java.util.concurrent.TimeUnit
+
+/**
+ * Central point to build and provide network stack components.
+ * Keeps REST implementation details hidden from upper layers.
+ */
+object NetworkProvider {
+
+    private val loggingInterceptor: HttpLoggingInterceptor by lazy {
+        HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BASIC
+        }
+    }
+
+    private val okHttpClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .addInterceptor(loggingInterceptor)
+            .connectTimeout(20, TimeUnit.SECONDS)
+            .readTimeout(20, TimeUnit.SECONDS)
+            .writeTimeout(20, TimeUnit.SECONDS)
+            .build()
+    }
+
+    private val moshi: Moshi by lazy {
+        Moshi.Builder()
+            .add(KotlinJsonAdapterFactory())
+            .build()
+    }
+
+    private val retrofit: Retrofit by lazy {
+        Retrofit.Builder()
+            .baseUrl(BuildConfig.BASE_URL)
+            .client(okHttpClient)
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .addCallAdapterFactory(
+                RxJava3CallAdapterFactory.createWithScheduler(Schedulers.io())
+            )
+            .build()
+    }
+
+    val recipesRequest: RecipesRequest by lazy {
+        retrofit.create(RecipesRequest::class.java)
+    }
+
+    val recipesDataSource: RecipesDataSource by lazy {
+        RecipesDataSourceImp(recipesRequest)
+    }
+}

--- a/app/src/test/java/com/example/myrecipebook/rest/api/RecipesRequestTest.kt
+++ b/app/src/test/java/com/example/myrecipebook/rest/api/RecipesRequestTest.kt
@@ -1,0 +1,140 @@
+package com.example.myrecipebook.rest.api
+
+import com.example.myrecipebook.rest.message.RecipeMessage
+import com.example.myrecipebook.rest.message.RecipesPageMessage
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Retrofit
+import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+class RecipesRequestTest {
+
+    private lateinit var server: MockWebServer
+    private lateinit var api: RecipesRequest
+
+    @Before
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+
+        val moshi = Moshi.Builder()
+            .add(KotlinJsonAdapterFactory())
+            .build()
+        val retrofit = Retrofit.Builder()
+            .baseUrl(server.url("/"))
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
+            .build()
+
+        api = retrofit.create(RecipesRequest::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Test
+    fun `getRecipes returns list and pagination`() {
+        // Arrange
+        val body = """
+            {
+              "recipes": [
+                {
+                  "id": 1,
+                  "name": "Classic Margherita Pizza",
+                  "ingredients": ["Pizza dough", "Tomato sauce"],
+                  "instructions": ["Preheat oven"],
+                  "prepTimeMinutes": 20,
+                  "cookTimeMinutes": 15,
+                  "servings": 4,
+                  "difficulty": "Easy",
+                  "cuisine": "Italian",
+                  "caloriesPerServing": 300,
+                  "tags": ["Pizza","Italian"],
+                  "userId": 166,
+                  "image": "https://cdn.dummyjson.com/recipe-images/1.webp",
+                  "rating": 4.6,
+                  "reviewCount": 98,
+                  "mealType": ["Dinner"]
+                }
+              ],
+              "total": 50,
+              "skip": 0,
+              "limit": 30
+            }
+        """.trimIndent()
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(body)
+        )
+
+        // Act
+        val response: RecipesPageMessage = api.getRecipes(limit = 30, skip = 0).blockingGet()
+
+        // Assert
+        val request = server.takeRequest()
+        assertEquals("GET", request.method)
+        assertEquals("/recipes?limit=30&skip=0", request.path)
+
+        assertNotNull(response)
+        assertEquals(50, response.total)
+        assertEquals(0, response.skip)
+        assertEquals(30, response.limit)
+        assertEquals(1, response.recipes.size)
+        assertEquals(1, response.recipes.first().id)
+        assertEquals("Classic Margherita Pizza", response.recipes.first().name)
+    }
+
+    @Test
+    fun `getRecipeById returns one recipe`() {
+        // Arrange
+        val body = """
+            {
+              "id": 10,
+              "name": "Shrimp Scampi Pasta",
+              "ingredients": ["Linguine pasta","Shrimp"],
+              "instructions": ["Cook pasta"],
+              "prepTimeMinutes": 15,
+              "cookTimeMinutes": 20,
+              "servings": 3,
+              "difficulty": "Medium",
+              "cuisine": "Italian",
+              "caloriesPerServing": 400,
+              "tags": ["Pasta","Shrimp"],
+              "userId": 114,
+              "image": "https://cdn.dummyjson.com/recipe-images/10.webp",
+              "rating": 4.3,
+              "reviewCount": 5,
+              "mealType": ["Dinner"]
+            }
+        """.trimIndent()
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(body)
+        )
+
+        // Act
+        val response: RecipeMessage = api.getRecipeById(10).blockingGet()
+
+        // Assert
+        val request = server.takeRequest()
+        assertEquals("GET", request.method)
+        assertEquals("/recipes/10", request.path)
+
+        assertNotNull(response)
+        assertEquals(10, response.id)
+        assertEquals("Shrimp Scampi Pasta", response.name)
+        assertEquals("Medium", response.difficulty)
+    }
+}


### PR DESCRIPTION
- Implemented a clean REST layer: Retrofit interface RecipesRequest, Kotlin message models, and mapper to domain, encapsulated behind 
- RecipesDataSource/RecipesDataSourceImp.Added NetworkProvider (OkHttp + Moshi Kotlin adapter + RxJava3) reading BuildConfig.BASE_URL, and unit tests for RecipesRequest with MockWebServer.